### PR TITLE
Preload NPC packs during startup

### DIFF
--- a/src/uiAndApp.js
+++ b/src/uiAndApp.js
@@ -951,7 +951,20 @@ export async function startGame(canvas) {
   activeLayout = settings.getControlScheme();
   updateHudHints(activeLayout);
 
-  const assets = await loadMallAssets();
+  const mallAssetsPromise = loadMallAssets();
+  const npcPacksPromise = loadNpcPacks().catch((error) => {
+    console.error('[NPC] Failed to load NPC packs:', error);
+    return null;
+  });
+
+  const assets = await mallAssetsPromise;
+  const npcPacks = await npcPacksPromise;
+  if (npcPacks) {
+    const { animatedMenVariants = [], animatedWomenVariants = [] } = npcPacks;
+    assets.animatedMenVariants = animatedMenVariants;
+    assets.animatedWomenVariants = animatedWomenVariants;
+    assets.npcPacksReady = true;
+  }
   const {
     renderer,
     scene,
@@ -1223,7 +1236,6 @@ export async function startGame(canvas) {
       });
     }
   }
-  let npcPacksLoading = false;
 
   let resetInProgress = false;
   // Build spawn selector UI module
@@ -1543,31 +1555,6 @@ export async function startGame(canvas) {
     scooter.sync(delta);
     mall.sync(delta);
     updateCamera(scooter.mesh);
-
-    // Kick off lazy NPC pack loading once to improve startup and upgrade future spawns
-    if (!assets.npcPacksReady && !npcPacksLoading) {
-      npcPacksLoading = true;
-      loadNpcPacks()
-        .then(({ animatedMenVariants, animatedWomenVariants }) => {
-          assets.animatedMenVariants = animatedMenVariants;
-          assets.animatedWomenVariants = animatedWomenVariants;
-          assets.npcPacksReady = true;
-        })
-        .then(() => {
-          try {
-            if (mall && typeof mall.addPatrons === 'function') {
-              // Add a fresh batch of higher-fidelity NPCs now that packs are ready
-              mall.addPatrons(14);
-            }
-          } finally {
-            npcPacksLoading = false;
-          }
-        })
-        .catch((error) => {
-          console.error('[NPC] Failed to load NPC packs:', error);
-          npcPacksLoading = false;
-        });
-    }
 
     renderer.render(scene, camera);
   }


### PR DESCRIPTION
## Summary
- load mall and NPC asset packs in parallel and populate the asset bundle with variant data before the mall is created
- remove the late NPC pack fetch from the render loop so patrons use the higher fidelity variants right away

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f917bf180c832c8a91e390f77398be